### PR TITLE
Add RubyMine prebuild config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,3 +20,8 @@ tasks:
 vscode:
   extensions:
     - rebornix.ruby
+
+jetbrains:
+  rubymine:
+    prebuilds:
+      version: both


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that https://github.com/gitpod-io/gitpod/pull/13612 has been merged, we can use [prebuilds](https://www.gitpod.io/docs/configure/projects/prebuilds) in this repository.